### PR TITLE
Feature/8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.github.nderwin.micro-playground</groupId>
+    <artifactId>micro-parent</artifactId>
+    <version>1.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>security</module>
+        <module>serviceone</module>
+        <module>servicetwo</module>
+    </modules>
+
+</project>

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -2,6 +2,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     
+    <parent>
+        <groupId>com.github.nderwin.micro-playground</groupId>
+        <artifactId>micro-parent</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    
     <groupId>com.github.nderwin.micro-playground</groupId>
     <artifactId>security</artifactId>
     <version>1.1.0-SNAPSHOT</version>

--- a/security/src/main/java/com/github/nderwin/micro/playground/security/AuthenticationMechanism.java
+++ b/security/src/main/java/com/github/nderwin/micro/playground/security/AuthenticationMechanism.java
@@ -1,6 +1,6 @@
 package com.github.nderwin.micro.playground.security;
 
-import com.github.nderwin.micro.playground.security.jwt.Credential;
+import com.github.nderwin.micro.playground.security.jwt.TokenCredential;
 import com.github.nderwin.micro.playground.security.jwt.TokenHandler;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -30,7 +30,7 @@ public class AuthenticationMechanism implements HttpAuthenticationMechanism {
         String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
         
         if (null != authHeader) {
-            Credential credential = tokenHandler.retrieveCredential(authHeader);
+            TokenCredential credential = tokenHandler.retrieveCredential(authHeader);
             
             CredentialValidationResult result = identityStoreHandler.validate(credential);
             

--- a/security/src/main/java/com/github/nderwin/micro/playground/security/boundary/AuthenticationResource.java
+++ b/security/src/main/java/com/github/nderwin/micro/playground/security/boundary/AuthenticationResource.java
@@ -15,7 +15,6 @@ import javax.inject.Inject;
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
-import javax.persistence.EntityExistsException;
 import javax.persistence.EntityManager;
 import javax.persistence.NoResultException;
 import javax.persistence.NonUniqueResultException;
@@ -118,11 +117,7 @@ public class AuthenticationResource {
         Caller c = new Caller(user.username, passwordHash.generate(user.password.toCharArray()));
         c.addRole("USER");
         
-        try {
-            em.persist(c);
-        } catch (EntityExistsException ex) {
-            return Response.status(Response.Status.CONFLICT).build();
-        }
+        em.persist(c);
         
         return Response.created(URI.create(request.getRequestURI() + "/login")).build();
     }

--- a/security/src/main/java/com/github/nderwin/micro/playground/security/boundary/User.java
+++ b/security/src/main/java/com/github/nderwin/micro/playground/security/boundary/User.java
@@ -1,0 +1,21 @@
+package com.github.nderwin.micro.playground.security.boundary;
+
+import java.io.Serializable;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+@XmlAccessorType(value = XmlAccessType.FIELD)
+public class User implements Serializable {
+    
+    private static final long serialVersionUID = 1L;
+
+    @XmlElement(nillable = false, required = true)
+    public String username;
+
+    @XmlElement(nillable = false, required = true)
+    public String password;
+    
+}

--- a/security/src/main/java/com/github/nderwin/micro/playground/security/jwt/IdentityStore.java
+++ b/security/src/main/java/com/github/nderwin/micro/playground/security/jwt/IdentityStore.java
@@ -2,6 +2,7 @@ package com.github.nderwin.micro.playground.security.jwt;
 
 import java.util.HashSet;
 import java.util.Set;
+import javax.security.enterprise.credential.Credential;
 import javax.security.enterprise.identitystore.CredentialValidationResult;
 
 import static javax.security.enterprise.identitystore.CredentialValidationResult.NOT_VALIDATED_RESULT;
@@ -9,15 +10,15 @@ import static javax.security.enterprise.identitystore.CredentialValidationResult
 public class IdentityStore implements javax.security.enterprise.identitystore.IdentityStore {
     
     @Override
-    public CredentialValidationResult validate(final javax.security.enterprise.credential.Credential credential) {
-        if (credential instanceof Credential) {
-            return validate((Credential) credential);
+    public CredentialValidationResult validate(final Credential credential) {
+        if (credential instanceof TokenCredential) {
+            return validate((TokenCredential) credential);
         }
 
         return NOT_VALIDATED_RESULT;
     }
 
-    private CredentialValidationResult validate(final Credential credential) {
+    private CredentialValidationResult validate(final TokenCredential credential) {
         String caller = credential.getSubject();
         Set<String> groups = new HashSet<>(credential.getScope());
         

--- a/security/src/main/java/com/github/nderwin/micro/playground/security/jwt/TokenCredential.java
+++ b/security/src/main/java/com/github/nderwin/micro/playground/security/jwt/TokenCredential.java
@@ -7,25 +7,34 @@ import javax.json.Json;
 import javax.json.JsonArrayBuilder;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
+import javax.security.enterprise.credential.Credential;
 
-public class Credential implements javax.security.enterprise.credential.Credential {
+public class TokenCredential implements Credential {
 
     private final Claims claims;
 
-    public Credential(final Claims claims) {
+    public TokenCredential(final Claims claims) {
+        if (null == claims) {
+            throw new IllegalArgumentException("Claims must not be null");
+        }
+        
         this.claims = claims;
     }
 
     public String getSubject() {
-        return (null == this.claims) ? null : this.claims.getSubject();
+        return this.claims.getSubject();
     }
 
     public List getScope() {
-        return (null == this.claims) ? null : this.claims.get("scope", List.class);
+        return this.claims.get("scope", List.class);
     }
 
     public Date getExpirationDate() {
-        return (null == this.claims) ? null : new Date(this.claims.getExpiration().getTime());
+        if (null != this.claims.getExpiration()) {
+            return new Date(this.claims.getExpiration().getTime());
+        }
+        
+        return null;
     }
 
     public JsonObject toJson() {

--- a/security/src/main/java/com/github/nderwin/micro/playground/security/jwt/TokenHandler.java
+++ b/security/src/main/java/com/github/nderwin/micro/playground/security/jwt/TokenHandler.java
@@ -82,8 +82,8 @@ public class TokenHandler {
         return jwt;
     }
     
-    public Credential retrieveCredential(final String token) {
-        Credential credential = null;
+    public TokenCredential retrieveCredential(final String token) {
+        TokenCredential credential = null;
         
         String jwt = stripHeader(token);
         
@@ -96,7 +96,7 @@ public class TokenHandler {
                 throw new ExpiredJwtException(claims.getHeader(), claims.getBody(), "Token has been invalidated");
             }
             
-            credential = new Credential(claims.getBody());
+            credential = new TokenCredential(claims.getBody());
         } catch (ExpiredJwtException | UnsupportedJwtException | MalformedJwtException | SignatureException | IllegalArgumentException ex) {
             LOG.log(Level.WARNING, ex.getMessage(), ex);
         }

--- a/serviceone/pom.xml
+++ b/serviceone/pom.xml
@@ -2,6 +2,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>com.github.nderwin.micro-playground</groupId>
+        <artifactId>micro-parent</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    
     <groupId>com.github.nderwin.micro-playground</groupId>
     <artifactId>serviceone</artifactId>
     <version>1.1.0-SNAPSHOT</version>

--- a/serviceone/src/main/java/com/github/nderwin/micro/playground/one/IdentityStore.java
+++ b/serviceone/src/main/java/com/github/nderwin/micro/playground/one/IdentityStore.java
@@ -33,7 +33,7 @@ public class IdentityStore implements javax.security.enterprise.identitystore.Id
     
     private CredentialValidationResult validate(final CallerOnlyCredential credential) {
         Client client = ClientBuilder.newClient();
-        WebTarget target = client.target("http://security:8080/security/resources/authentication/info");
+        WebTarget target = client.target("http://security:8080/security/resources/authentication");
         
         try {
             JsonObject response = target

--- a/servicetwo/pom.xml
+++ b/servicetwo/pom.xml
@@ -2,6 +2,13 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>com.github.nderwin.micro-playground</groupId>
+        <artifactId>micro-parent</artifactId>
+        <version>1.1.0-SNAPSHOT</version>
+        <relativePath>../</relativePath>
+    </parent>
+    
     <groupId>com.github.nderwin.micro-playground</groupId>
     <artifactId>servicetwo</artifactId>
     <version>1.1.0-SNAPSHOT</version>

--- a/servicetwo/src/main/java/com/github/nderwin/micro/playground/two/IdentityStore.java
+++ b/servicetwo/src/main/java/com/github/nderwin/micro/playground/two/IdentityStore.java
@@ -33,7 +33,7 @@ public class IdentityStore implements javax.security.enterprise.identitystore.Id
     
     private CredentialValidationResult validate(final CallerOnlyCredential credential) {
         Client client = ClientBuilder.newClient();
-        WebTarget target = client.target("http://security:8080/security/resources/authentication/info");
+        WebTarget target = client.target("http://security:8080/security/resources/authentication");
         
         try {
             JsonObject response = target


### PR DESCRIPTION
- introduced a parent pom to make building all of the projects easier, and makes it easier to get to the non-maven project files in the IDE
- re-arranged the null checks in Credential, then renamed it to TokenCredential to remove the need to fully qualify Credential from the security API
- changed the URL for returning authn/authz info, which means the serviceone and servicetwo IdentityStores needed to be updated
- added a way to create users through the REST API to keep from having to manually enter data into the database
- added a JAX-RS transfer object, instead of using JsonObject for new user creation to act as a comparison to JsonObject